### PR TITLE
add use of precomputed bedtools multicov coverage tsv file

### DIFF
--- a/script/ifCNV
+++ b/script/ifCNV
@@ -153,6 +153,13 @@ if __name__ == "__main__":
         default=None,
         help='Path where lib to import for report.'
     )
+    parser.add_argument(
+        '-wC',
+        '--withCov',
+        default=False,
+        action='store_true',
+        help='if set (no argument), loads precomputed bedtools multicov .tsv file from input bam folder'
+    )
 
     args = parser.parse_args()
     ifCNV.main(args)


### PR DESCRIPTION
Hi
I added an option to use a formatted tsv output from "bedtools multicov" calculated outside ifCNV.
I hope you can add it if you are interested.
I am available to make modifications if necessary.

